### PR TITLE
Add bookmark conversations.updated_at

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/.vscode/*
+.vscode
+.DS_Store
 /.ipynb_checkpoints/*
 config/
 virtualenvs/
@@ -8,12 +9,12 @@ virtualenvs/
 target*.json
 *.sublime-*
 .python-version
-singer-check-tap-data
+singer-check-tap*
 *.pyc
 *.egg-info
 dist/
 __pycache__/
 venv/
 build/
-
+tap_target_commands.sh
 tap_helpscout/.vscode/settings.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.1
+  * Add `updated_at` as bookmark for `conversations`. This is a new bookmark field, based on max of 2 other datetimes in record.
+
 ## 1.0.0
   * Releasing from Beta --> GA
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ This tap:
 - Endpoint: https://api.helpscout.net/v2/conversations
 - Primary keys: id
 - Foreign keys: mailbox_id (mailboxes), assignee > id (users), created_by > id (users), primary_customer > id (customers), custom_fields > id (mailbox_fields)
-- Replication strategy: Incremental (query filtered)
-  - Bookmark query parameter: modifiedSince
+- Replication strategy: Incremental (query all, filter results)
+  - Filter: status = all
   - Sort by: modifiedAt ascending
-  - Bookmark: user_updated_at (date-time)
+  - Bookmark: updated_at
 - Transformations: Fields camelCase to snake_case
 - Children: conversation_threads
 
@@ -92,6 +92,41 @@ This tap:
 - Replication strategy: Incremental (query all, filter results)
   - Bookmark: modified_at (date-time)
 - Transformations: Fields camelCase to snake_case.
+
+
+## Authentication
+[Refresh Access Token](https://developer.helpscout.com/mailbox-api/overview/authentication/#4-refresh-access-token)
+The tap should provides a `refresh_token`, `client_id` and `client_secret` to get an `access_token` when the tap starts. If/when the access_token expires in the middle of a run, the tap gets a new `access_token` and `refresh_token`. The `refresh_token` expires every use and new one is generated and persisted in the tap `config.json` until the next authentication.
+To generate the necessary API keys: `client_id` and `client_secret`, follow these instructions to [Create My App](https://developer.helpscout.com/mailbox-api/overview/authentication/#oauth2-application) in your User Profile of the HelpScout web console application.
+- App Name: tap-helpscout
+- Redirect URL: https://app.stitchdata.test:8080/v2/integrations/platform.helpscout/callback
+Record your credentials (for the tap config.json):
+- App ID: `client_id`
+- App Secret: `client_secret`
+
+Authentication URL: https://secure.helpscout.net/authentication/authorizeClientApplication?client_id=`YOUR_CLIENT_ID`&state=`YOUR_CLIENT_SECRET`
+Adjust the above URL by replacing `YOUR_CLIENT_ID` and `YOUR_CLIENT_SECRET`. In your web browser, disable any ad/popup blockers, and navigate to the Authorize URL. Click Authorize and you will be redirected to your Redirect URL (from above). Record the `code` from the redirected browser URL in the browser header.
+
+Authentication curl: Run the following curl command (from the command line or REST client) with the parameters replaced to return your access_token and refresh_token. This is a POST request.
+```bash
+> curl -0 -v -X POST https://api.helpscout.net/v2/oauth2/token
+    -H "Accept: application/json"\
+    -H "application/x-www-form-urlencoded"\
+    -d "grant_type=authorization_code"\
+    -d "code=YOUR_CODE"\
+    -d "client_id=YOUR_CLIENT_ID"\
+    -d "client_secret=YOUR_CLIENT_SECRET"
+```
+Record your `client_id`, `client_secret`, and the returned `refresh_token` into your tap `config.json`, which should look like the following:
+
+    ```json
+    {
+        "client_id": "OAUTH_CLIENT_ID",
+        "client_secret": "OAUTH_CLIENT_SECRET",
+        "refresh_token": "YOUR_OAUTH_REFRESH_TOKEN",
+        "start_date": "2017-04-19T13:37:30Z"
+    }
+    ```
 
 ## Quick Start
 

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,15 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-helpscout',
-      version='1.0.0',
+      version='1.0.1',
       description='Singer.io tap for extracting data from the HelpScout Mailbox API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_helpscout'],
       install_requires=[
           'backoff==1.8.0',
-          'requests==2.20.0',
-          'singer-python==5.8.0'
+          'requests==2.23.0',
+          'singer-python==5.9.0'
       ],
       entry_points='''
           [console_scripts]

--- a/tap_helpscout/schema.py
+++ b/tap_helpscout/schema.py
@@ -8,7 +8,7 @@ STREAMS = {
     'conversations': {
         'key_properties': ['id'],
         'replication_method': 'INCREMENTAL',
-        'replication_keys': ['user_updated_at']
+        'replication_keys': ['updated_at']
     },
     'conversation_threads': {
         'key_properties': ['id'],

--- a/tap_helpscout/schemas/conversations.json
+++ b/tap_helpscout/schemas/conversations.json
@@ -84,6 +84,10 @@
       "type": ["null", "string"],
       "format": "date-time"
     },
+    "updated_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
     "closed_by": {
       "type": ["null", "integer"]
     },

--- a/tap_helpscout/sync.py
+++ b/tap_helpscout/sync.py
@@ -171,9 +171,10 @@ def sync_endpoint(client,
         children = endpoint_config.get('children')
         if children:
             for child_stream_name, child_endpoint_config in children.items():
-                should_stream, last_stream_child = should_sync_stream(get_selected_streams(catalog),
-                                                            None,
-                                                            child_stream_name)
+                should_stream, last_stream_child = should_sync_stream(
+                    get_selected_streams(catalog),
+                    None,
+                    child_stream_name)
                 if should_stream:
                     for record in transformed_data:
                         parent_id = record.get('id')
@@ -290,7 +291,6 @@ def sync(client, catalog, state, start_date):
                 'sortOrder': 'asc'
             },
             'data_key': 'conversations',
-            'bookmark_query_field': 'modifiedSince',
             'bookmark_field': 'user_updated_at',
             'bookmark_type': 'datetime',
             'id_field': 'id',


### PR DESCRIPTION
# Description of change
Add `updated_at` as bookmark for `conversations`. This is a new bookmark field, based on max of 2 other datetimes in record. This fixes an issue identified in Slack tap-helpscout channel.

# Manual QA steps
Made dev changes. Ran singer-discover, singer-check-tap, and sync to target-stitch (initial load and incremental). No issues.
 
# Risks
New bookmark field. Recommend re-sync history, especially conversations and conversation_threads.
 
# Rollback steps
Revert to v1.0.0
