### PR TITLE
v1.0.3 conversations updated_at bookmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.3
+  * Change `conversations` to use bookmark `modifiedSince` filter param to improve bookmarking and reduce the data volumes queried.
+
 ## 1.0.2
   * Get max `updated_at` for `conversations` even if `None`.
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ Record your `client_id`, `client_secret`, and the returned `refresh_token` into 
         "client_id": "OAUTH_CLIENT_ID",
         "client_secret": "OAUTH_CLIENT_SECRET",
         "refresh_token": "YOUR_OAUTH_REFRESH_TOKEN",
-        "start_date": "2017-04-19T13:37:30Z"
+        "start_date": "2017-04-19T13:37:30Z",
+        "user_agent": "tap-helpscout <user@domain.com>"
     }
     ```
     
@@ -229,24 +230,24 @@ Record your `client_id`, `client_secret`, and the returned `refresh_token` into 
     The output is valid.
     It contained 150 messages for 8 streams.
 
-        20 schema messages
-        111 record messages
-        19 state messages
+          8 schema messages
+        124 record messages
+        18 state messages
 
     Details by stream:
     +----------------------+---------+---------+
     | stream               | records | schemas |
     +----------------------+---------+---------+
-    | workflows            | 7       | 1       |
-    | users                | 3       | 1       |
+    | conversations        | 17      | 1       |
+    | customers            | 56      | 1       |
+    | users                | 4       | 1       |
+    | mailbox_folders      | 9       | 1       |
+    | workflows            | 2       | 1       |
+    | conversation_threads | 32      | 1       |
+    | mailbox_fields       | 2       | 1       |
     | mailboxes            | 2       | 1       |
-    | conversation_threads | 22      | 11      |
-    | mailbox_folders      | 9       | 2       |
-    | mailbox_fields       | 5       | 2       |
-    | conversations        | 11      | 1       |
-    | customers            | 52      | 1       |
     +----------------------+---------+---------+
     ```
 ---
 
-Copyright &copy; 2019 Stitch
+Copyright &copy; 2020 Stitch

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-helpscout',
-      version='1.0.2',
+      version='1.0.3',
       description='Singer.io tap for extracting data from the HelpScout Mailbox API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_helpscout/sync.py
+++ b/tap_helpscout/sync.py
@@ -110,8 +110,6 @@ def sync_endpoint(client,
         last_datetime = get_bookmark(state, stream_name, start_date)
         max_bookmark_value = last_datetime
 
-    write_schema(catalog, stream_name)
-
     # pagination: loop thru all pages of data
     page = 1
     total_pages = 1  # initial value, set with first API call
@@ -176,6 +174,7 @@ def sync_endpoint(client,
                     None,
                     child_stream_name)
                 if should_stream:
+                    write_schema(catalog, child_stream_name)
                     for record in transformed_data:
                         parent_id = record.get('id')
                         LOGGER.info('Syncing: {}, parent_id: {}'.format(child_stream_name, parent_id))
@@ -291,7 +290,8 @@ def sync(client, catalog, state, start_date):
                 'sortOrder': 'asc'
             },
             'data_key': 'conversations',
-            'bookmark_field': 'user_updated_at',
+            'bookmark_query_field': 'modifiedSince',
+            'bookmark_field': 'updated_at',
             'bookmark_type': 'datetime',
             'id_field': 'id',
             'children': {
@@ -367,6 +367,7 @@ def sync(client, catalog, state, start_date):
         if should_stream:
             LOGGER.info('START Syncing: {}'.format(stream_name))
             update_currently_syncing(state, stream_name)
+            write_schema(catalog, stream_name)
 
             path = endpoint_config.get('path')
             total_records = sync_endpoint(


### PR DESCRIPTION
# Description of change
Change `conversations` to use bookmark `modifiedSince` filter param to improve bookmarking and reduce the data volumes queried. Fix `write_schema` to only run once per endpoint.

# Manual QA steps
Ran singer-discover, singer-check-tap, target-stitch (both initial load and incremental subsequent load). All endpoints load as expected. Verified only most recent (last bookmark) and new/modified conversations are included in query.
 
# Risks
Low. This fixes an urgent issue where conversations load times are taking very long, b/c each load is querying ALL conversations and filtering results based on bookmark. This will adjust to query for conversations on/after the last bookmark, reducing the queried data volumes.
 
# Rollback steps
Revert to v1.0.0
