### PR TITLE
use tap-tester-v4 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,13 +24,13 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-a-test --tap=tap-helpscout \
-                       --target=target-stitch \
-                       --orchestrator=stitch-orchestrator \
-                       --email=harrison+sandboxtest@stitchdata.com \
-                       --password=$SANDBOX_PASSWORD \
-                       --client-id=50 \
-                       tap_tester.suites.helpscout
+            run-test --tap=tap-helpscout \
+                     --target=target-stitch \
+                     --orchestrator=stitch-orchestrator \
+                     --email=harrison+sandboxtest@stitchdata.com \
+                     --password=$SANDBOX_PASSWORD \
+                     --client-id=50 \
+                     tests
 workflows:
   version: 2
   commit:

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,81 @@
+"""
+Test tap combined
+"""
+
+import unittest
+import os
+
+from tap_tester import menagerie
+import tap_tester.runner as runner
+import tap_tester.connections as connections
+
+
+class BaseHelpscoutTest(unittest.TestCase):
+    """ Test the tap combined """
+
+    def name(self):
+        return "tap_helpscout_combined_test"
+
+    def tap_name(self):
+        """The name of the tap"""
+        return "tap-helpscout"
+
+    def get_type(self):
+        """the expected url route ending"""
+        return "platform.helpscout"
+
+    def expected_check_streams(self):
+        return {
+            'conversations',
+            'conversation_threads',
+            'customers',
+            'mailboxes',
+            'mailbox_fields',
+            'mailbox_folders',
+            'users',
+            'workflows'
+        }
+
+    def expected_sync_streams(self):
+        return {
+            'conversations',
+            'conversation_threads',
+            'customers',
+            'mailboxes',
+            'mailbox_fields',
+            'mailbox_folders',
+            'users',
+            'workflows'
+        }
+
+    def expected_pks(self):
+        return {
+            'conversations': {"id"},
+            'conversation_threads': {"id"},
+            'customers': {"id"},
+            'mailboxes': {"id"},
+            'mailbox_fields': {"id"},
+            'mailbox_folders': {"id"},
+            'users': {"id"},
+            'workflows': {"id"}
+        }
+
+    def get_properties(self):
+        """Configuration properties required for the tap."""
+        return {'start_date': os.getenv('TAP_HELPSCOUT_START_DATE', '2018-01-01 00:00:00')}
+
+    def get_credentials(self):
+        """Authentication information for the test account"""
+        return {'refresh_token': os.getenv('TAP_HELPSCOUT_REFRESH_TOKEN'),
+                'client_secret': os.getenv('TAP_HELPSCOUT_CLIENT_SECRET'),
+                'client_id': os.getenv('TAP_HELPSCOUT_CLIENT_ID')}
+
+    def required_environment_variables(self):
+        return set(['TAP_HELPSCOUT_REFRESH_TOKEN',
+                    'TAP_HELPSCOUT_CLIENT_SECRET',
+                    'TAP_HELPSCOUT_CLIENT_ID'])
+
+    def setUp(self):
+        missing_envs = [x for x in self.required_environment_variables() if os.getenv(x) is None]
+        if missing_envs:
+            raise Exception("Missing environment variables, please set {}." .format(missing_envs))

--- a/tests/base.py
+++ b/tests/base.py
@@ -62,7 +62,7 @@ class BaseHelpscoutTest(unittest.TestCase):
 
     def get_properties(self):
         """Configuration properties required for the tap."""
-        return {'start_date': os.getenv('TAP_HELPSCOUT_START_DATE', '2018-01-01 00:00:00')}
+        return {'start_date': os.getenv('TAP_HELPSCOUT_START_DATE', '2018-01-01T00:00:00Z')}
 
     def get_credentials(self):
         """Authentication information for the test account"""

--- a/tests/test_helpscout_combined.py
+++ b/tests/test_helpscout_combined.py
@@ -1,0 +1,86 @@
+"""
+Test tap combined
+"""
+
+import unittest
+import os
+
+from tap_tester import menagerie
+import tap_tester.runner as runner
+import tap_tester.connections as connections
+
+
+class HelpscoutCombinedTest(BaseHelpscoutTest):
+    """ Test the tap combined """
+
+    def name(self):
+        return "tap_helpscout_combined_test"
+
+    def test_run(self):
+
+        def preserve_refresh_token(existing_conns, payload):
+            if not existing_conns:
+                return payload
+            conn_with_creds = connections.fetch_existing_connection_with_creds(existing_conns[0]['id'])
+            payload['credentials']['refresh_token'] = conn_with_creds['credentials']['refresh_token']
+            return payload
+
+        conn_id = connections.ensure_connection(self, payload_hook=preserve_refresh_token)
+
+        # Run the tap in check mode
+        check_job_name = runner.run_check_mode(self, conn_id)
+
+        # Verify the check's exit status
+        exit_status = menagerie.get_exit_status(conn_id, check_job_name)
+        menagerie.verify_check_exit_status(self, exit_status, check_job_name)
+
+        # Verify that there are catalogs found
+        found_catalogs = menagerie.get_catalogs(conn_id)
+        self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
+
+        found_catalog_names = set(map(lambda c: c['tap_stream_id'], found_catalogs))
+        subset = self.expected_check_streams().issubset(found_catalog_names)
+        self.assertTrue(subset, msg="Expected check streams are not subset of discovered catalog")
+        #
+        # # Select some catalogs
+        our_catalogs = [c for c in found_catalogs if c.get('tap_stream_id') in self.expected_sync_streams()]
+        for catalog in our_catalogs:
+            schema = menagerie.get_annotated_schema(conn_id, catalog['stream_id'])
+            connections.select_catalog_and_fields_via_metadata(conn_id, catalog, schema, [], [])
+
+        # # Verify that all streams sync at least one row for initial sync
+        # # This test is also verifying access token expiration handling. If test fails with
+        # # authentication error, refresh token was not replaced after expiring.
+        menagerie.set_state(conn_id, {})
+        sync_job_name = runner.run_sync_mode(self, conn_id)
+
+        # # Verify tap and target exit codes
+        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
+        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+        record_count_by_stream = runner.examine_target_output_file(self, conn_id, self.expected_sync_streams(),
+                                                                   self.expected_pks())
+        zero_count_streams = {k for k, v in record_count_by_stream.items() if v == 0}
+        self.assertFalse(zero_count_streams,
+                         msg="The following streams did not sync any rows {}".format(zero_count_streams))
+
+        # # Verify that all streams sync only one row for incremental sync
+        sync_job_name = runner.run_sync_mode(self, conn_id)
+        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
+        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+        record_count_by_stream = runner.examine_target_output_file(self, conn_id, self.expected_sync_streams(),
+                                                                   self.expected_pks())
+        # Exclude streams in which multiple rows may exist for a bookmark value
+        error_incremental_streams = {k for k, v in record_count_by_stream.items() if
+                                     v > 1 and k not in {'mailbox_fields'}}
+        self.assertFalse(error_incremental_streams,
+                         msg="The following streams synced more than 1 row {}".format(error_incremental_streams))
+
+        # # Verify that bookmark values are correct after incremental sync
+        current_state = menagerie.get_state(conn_id)
+        conversations_bookmark = current_state['bookmarks']['conversations']
+
+        # NB: We use a greater than or equal to in case data is added
+        # after our expected value
+        self.assertTrue(conversations_bookmark >= '2019-06-21T20:36:54Z',
+                        msg=("The bookmark value does not match the expected result: " +
+                             "(Actual {} not >= Expected 2019-06-21T20:36:54Z)".format(conversations_bookmark)))

--- a/tests/test_helpscout_combined.py
+++ b/tests/test_helpscout_combined.py
@@ -9,6 +9,8 @@ from tap_tester import menagerie
 import tap_tester.runner as runner
 import tap_tester.connections as connections
 
+from base import BaseHelpscoutTest
+
 
 class HelpscoutCombinedTest(BaseHelpscoutTest):
     """ Test the tap combined """

--- a/tests/test_helpscout_combined.py
+++ b/tests/test_helpscout_combined.py
@@ -24,7 +24,7 @@ class HelpscoutCombinedTest(BaseHelpscoutTest):
             if not existing_conns:
                 return payload
             conn_with_creds = connections.fetch_existing_connection_with_creds(existing_conns[0]['id'])
-            payload['credentials']['refresh_token'] = conn_with_creds['credentials']['refresh_token']
+            payload['properties']['refresh_token'] = conn_with_creds['credentials']['refresh_token']
             return payload
 
         conn_id = connections.ensure_connection(self, payload_hook=preserve_refresh_token)


### PR DESCRIPTION
# Description of change
Use the v4 tap-tester image. The idea is this will prevent failures to source the environment during nightly builds.

# Manual QA steps
 - None
 
# Risks
 - None, change to tap-tester image.
 
# Rollback steps
 - revert this branch
