### PR TITLE
Added a temporary fail method

### DIFF
--- a/tests/test_helpscout_combined.py
+++ b/tests/test_helpscout_combined.py
@@ -20,6 +20,8 @@ class HelpscoutCombinedTest(BaseHelpscoutTest):
 
     def test_run(self):
 
+        self.fail('Temporarily failing because of refresh token issue')
+
         def preserve_refresh_token(existing_conns, payload):
             if not existing_conns:
                 return payload


### PR DESCRIPTION
# Description of change
Added a temporary fail method, so that the Circle CI tests fails as we are trying to resolve a refresh token issue which involves conflicts when executed across environments

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
