### PR TITLE
SAC-28843: Added parent-tap-stream-id to metadata for child streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.0
+  * Adds parent-tap-stream-id field to catalog for child streams [#42](https://github.com/singer-io/tap-helpscout/pull/42)
+
 ## 1.2.1
 * Dependency upgrades [#40](https://github.com/singer-io/tap-helpscout/pull/40)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="tap-helpscout",
-    version="1.2.1",
+    version="1.3.0",
     description="Singer.io tap for extracting data from the HelpScout Mailbox API 2.0",
     author="jeff.huth@bytecode.io",
     classifiers=["Programming Language :: Python :: 3 :: Only"],

--- a/tap_helpscout/discover.py
+++ b/tap_helpscout/discover.py
@@ -1,6 +1,7 @@
 import json
 from typing import Dict, Tuple
 
+from singer import metadata
 from singer.catalog import Catalog
 
 from tap_helpscout.helpers import get_abs_path
@@ -28,14 +29,25 @@ def discover():
     streams = []
 
     for schema_name, schema in schemas.items():
+        stream_cls = STREAMS[schema_name]
         schema_meta = schema_metadata[schema_name]
+        mdata = metadata.to_map(schema_meta)
+
+        # Add parent-tap-stream-id if this is a child stream
+        is_child = getattr(stream_cls, "is_child", False)
+        parent_tap_stream_id = getattr(stream_cls, "parent", None) if is_child else None
+        if parent_tap_stream_id:
+            mdata = metadata.write(mdata, (), "parent-tap-stream-id", parent_tap_stream_id)
+        
+        mdata = metadata.to_list(mdata)
+        
         streams.append(
             {
                 "stream": schema_name,
                 "tap_stream_id": schema_name,
-                "key_properties": STREAMS[schema_name].key_properties,
+                "key_properties": stream_cls.key_properties,
                 "schema": schema,
-                "metadata": schema_meta,
+                "metadata": mdata,
             }
         )
     return Catalog.from_dict({"streams": streams})

--- a/tap_helpscout/streams/abstract.py
+++ b/tap_helpscout/streams/abstract.py
@@ -145,7 +145,7 @@ class BaseStream(ABC):
             with metrics.record_counter(self.tap_stream_id) as counter:
                 for record in self.get_records(state, parent_id):
                     if parent_id:
-                        record[f"{self.parent}_id"] = parent_id
+                        record[self.parent_id_field] = parent_id
                     transformed_record = transformer.transform(record, schema, stream_metadata)
                     # Insert the parentId into each child record
                     if self.replication_key and self.replication_key in transformed_record:
@@ -212,6 +212,7 @@ class IncrementalStream(BaseStream):
     replication_query_field = ""
     child_streams = []
     parent = ""
+    parent_id_field = ""
 
 
 class FullStream(BaseStream):
@@ -224,3 +225,4 @@ class FullStream(BaseStream):
     params = {}
     child_streams = []
     parent = ""
+    parent_id_field = ""

--- a/tap_helpscout/streams/abstract.py
+++ b/tap_helpscout/streams/abstract.py
@@ -83,6 +83,8 @@ class BaseStream(ABC):
         order to allow for sources that have duplicate stream names.
         """
 
+    parent_id_field = ""
+
     def __init__(self, client=None, start_date=None) -> None:
         self.client = client
         self.start_date = start_date

--- a/tap_helpscout/streams/conversation_threads.py
+++ b/tap_helpscout/streams/conversation_threads.py
@@ -9,3 +9,4 @@ class ConversationThreads(FullStream):
     data_key = "threads"
     is_child = True
     parent = "conversations"
+    parent_id_field = "conversation_id"

--- a/tap_helpscout/streams/conversation_threads.py
+++ b/tap_helpscout/streams/conversation_threads.py
@@ -8,4 +8,4 @@ class ConversationThreads(FullStream):
     key_properties = ["id"]
     data_key = "threads"
     is_child = True
-    parent = "conversation"
+    parent = "conversations"

--- a/tap_helpscout/streams/mailbox_fields.py
+++ b/tap_helpscout/streams/mailbox_fields.py
@@ -8,4 +8,4 @@ class MailBoxFields(FullStream):
     key_properties = ["id"]
     data_key = "fields"
     is_child = True
-    parent = "mailbox"
+    parent = "mailboxes"

--- a/tap_helpscout/streams/mailbox_fields.py
+++ b/tap_helpscout/streams/mailbox_fields.py
@@ -9,3 +9,4 @@ class MailBoxFields(FullStream):
     data_key = "fields"
     is_child = True
     parent = "mailboxes"
+    parent_id_field = "mailbox_id"

--- a/tap_helpscout/streams/mailbox_folders.py
+++ b/tap_helpscout/streams/mailbox_folders.py
@@ -12,4 +12,4 @@ class MailBoxFolders(IncrementalStream):
     valid_replication_keys = ("updated_at",)
     data_key = "folders"
     is_child = True
-    parent = "mailbox"
+    parent = "mailboxes"

--- a/tap_helpscout/streams/mailbox_folders.py
+++ b/tap_helpscout/streams/mailbox_folders.py
@@ -13,3 +13,4 @@ class MailBoxFolders(IncrementalStream):
     data_key = "folders"
     is_child = True
     parent = "mailboxes"
+    parent_id_field = "mailbox_id"

--- a/tap_helpscout/streams/team_members.py
+++ b/tap_helpscout/streams/team_members.py
@@ -9,3 +9,4 @@ class TeamMembers(FullStream):
     data_key = "users"
     is_child = True
     parent = "teams"
+    parent_id_field = "team_id"

--- a/tap_helpscout/streams/team_members.py
+++ b/tap_helpscout/streams/team_members.py
@@ -8,4 +8,4 @@ class TeamMembers(FullStream):
     key_properties = ["team_id", "user_id"]
     data_key = "users"
     is_child = True
-    parent = "team"
+    parent = "teams"

--- a/tests/base.py
+++ b/tests/base.py
@@ -23,6 +23,7 @@ class HelpscoutBaseTest(unittest.TestCase):
     PRIMARY_KEYS = "table-key-properties"
     FOREIGN_KEYS = "table-foreign-key-properties"
     REPLICATION_METHOD = "forced-replication-method"
+    PARENT_TAP_STREAM_ID = "parent-tap-stream-id"
     API_LIMIT = 400
     INCREMENTAL = "INCREMENTAL"
     FULL_TABLE = "FULL_TABLE"

--- a/tests/base.py
+++ b/tests/base.py
@@ -99,12 +99,14 @@ class HelpscoutBaseTest(unittest.TestCase):
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.EXPECTED_PAGE_SIZE: 50,
+                self.EXPECTED_PARENT_STREAM: "mailboxes",
             },
             "mailbox_folders": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"updated_at"},
                 self.EXPECTED_PAGE_SIZE: 50,
+                self.EXPECTED_PARENT_STREAM: "mailboxes",
             },
             "teams": {
                 self.PRIMARY_KEYS: {"id"},
@@ -115,7 +117,8 @@ class HelpscoutBaseTest(unittest.TestCase):
             "team_members": {
                 self.PRIMARY_KEYS: {"team_id", "user_id"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
-                self.EXPECTED_PAGE_SIZE: 50
+                self.EXPECTED_PAGE_SIZE: 50,
+                self.EXPECTED_PARENT_STREAM: "teams",
             },
             "users": {
                 self.PRIMARY_KEYS: {"id"},

--- a/tests/test_helpscout_discovery.py
+++ b/tests/test_helpscout_discovery.py
@@ -83,9 +83,6 @@ class DiscoveryTest(HelpscoutBaseTest):
                 actual_replication_method = (
                     stream_properties[0].get("metadata", {self.REPLICATION_METHOD: None}).get(self.REPLICATION_METHOD)
                 )
-                
-                # Verify forced-replication-method is present 
-                actual_forced_replication_method = stream_properties[0].get("metadata", {}).get("forced-replication-method")
                 actual_automatic_fields = {
                     item.get("breadcrumb", ["properties", None])[1]
                     for item in metadata
@@ -93,7 +90,7 @@ class DiscoveryTest(HelpscoutBaseTest):
                 }
                 
                 # Get parent-tap-stream-id if present
-                actual_parent_stream_id = stream_properties[0].get("metadata", {}).get("parent-tap-stream-id")
+                actual_parent_stream_id = stream_properties[0].get("metadata", {}).get(self.PARENT_TAP_STREAM_ID)
                 
                 expected_parent_stream = self.expected_metadata().get(stream, {}).get(self.EXPECTED_PARENT_STREAM)
 
@@ -124,26 +121,18 @@ class DiscoveryTest(HelpscoutBaseTest):
                     f" but actual replication method is {actual_replication_method}",
                 )
 
-                # verify forced-replication-method matches expected value
-                self.assertEqual(
-                    expected_replication_method,
-                    actual_forced_replication_method,
-                    msg=f"expected forced-replication-method is {expected_replication_method}"
-                    f" but actual forced-replication-method is {actual_forced_replication_method}",
-                )
-
                 # verify parent-tap-stream-id for child streams
                 if expected_parent_stream:
                     self.assertEqual(
                         expected_parent_stream,
                         actual_parent_stream_id,
-                        msg=f"expected parent-tap-stream-id is {expected_parent_stream}"
-                        f" but actual parent-tap-stream-id is {actual_parent_stream_id}",
+                        msg=f"expected {self.PARENT_TAP_STREAM_ID} is {expected_parent_stream}"
+                        f" but actual {self.PARENT_TAP_STREAM_ID} is {actual_parent_stream_id}",
                     )
                 else:
                     self.assertIsNone(
                         actual_parent_stream_id,
-                        msg=f"parent-tap-stream-id should be None for parent stream {stream}"
+                        msg=f"{self.PARENT_TAP_STREAM_ID} should be None for parent stream {stream}"
                         f" but got {actual_parent_stream_id}",
                     )
 

--- a/tests/test_helpscout_discovery.py
+++ b/tests/test_helpscout_discovery.py
@@ -83,11 +83,19 @@ class DiscoveryTest(HelpscoutBaseTest):
                 actual_replication_method = (
                     stream_properties[0].get("metadata", {self.REPLICATION_METHOD: None}).get(self.REPLICATION_METHOD)
                 )
+                
+                # Verify forced-replication-method is present 
+                actual_forced_replication_method = stream_properties[0].get("metadata", {}).get("forced-replication-method")
                 actual_automatic_fields = {
                     item.get("breadcrumb", ["properties", None])[1]
                     for item in metadata
                     if item.get("metadata").get("inclusion") == "automatic"
                 }
+                
+                # Get parent-tap-stream-id if present
+                actual_parent_stream_id = stream_properties[0].get("metadata", {}).get("parent-tap-stream-id")
+                
+                expected_parent_stream = self.expected_metadata().get(stream, {}).get(self.EXPECTED_PARENT_STREAM)
 
                 ##########################################################################
                 # metadata assertions
@@ -115,6 +123,29 @@ class DiscoveryTest(HelpscoutBaseTest):
                     msg=f"expected replication method is {expected_replication_method}"
                     f" but actual replication method is {actual_replication_method}",
                 )
+
+                # verify forced-replication-method matches expected value
+                self.assertEqual(
+                    expected_replication_method,
+                    actual_forced_replication_method,
+                    msg=f"expected forced-replication-method is {expected_replication_method}"
+                    f" but actual forced-replication-method is {actual_forced_replication_method}",
+                )
+
+                # verify parent-tap-stream-id for child streams
+                if expected_parent_stream:
+                    self.assertEqual(
+                        expected_parent_stream,
+                        actual_parent_stream_id,
+                        msg=f"expected parent-tap-stream-id is {expected_parent_stream}"
+                        f" but actual parent-tap-stream-id is {actual_parent_stream_id}",
+                    )
+                else:
+                    self.assertIsNone(
+                        actual_parent_stream_id,
+                        msg=f"parent-tap-stream-id should be None for parent stream {stream}"
+                        f" but got {actual_parent_stream_id}",
+                    )
 
                 # Verify replication key is present for any stream with replication
                 # method = INCREMENTAL


### PR DESCRIPTION
# Description of change

This PR adds support for parent-tap-stream-id metadata to child streams in the HelpScout tap's discovery mechanism. This enhancement allows child streams to properly identify their parent stream relationships in the metadata.

- Imports the `singer.metadata` module to manipulate stream metadata
- Adds logic to detect child streams and set their parent-tap-stream-id metadata field
- Introduces an explicit `parent_id_field` attribute on `BaseStream`, `IncrementalStream` and `FullStream`. Replaces the dynamic construction `f"{self.parent}_id"` with `self.parent_id_field` when injecting the parent ID into child records.

[SAC-28843](https://qlik-dev.atlassian.net/browse/SAC-28843)

# Manual QA steps
- Run discovery and inspect the output catalog:
   ```
   tap-helpscout --config config.json --discover > catalog.json
   ```
- Confirm that child streams (`mailbox_fields`, `mailbox_folders`, `team_members`, `conversation_threads`) have `"parent-tap-stream-id"` set correctly in root-level metadata (e.g., `"mailboxes"`, `"teams"`, `"conversations"`).
- Confirm that parent streams (`mailboxes`, `teams`, `conversations`) do **not** have `parent-tap-stream-id` in their metadata.
- Run a sync and verify child records still receive the correct parent ID field (e.g., `conversation_id`, `mailbox_id`, `team_id`).
- Run the discovery test suite:
   ```
   python -m pytest tests/test_helpscout_discovery.py -v
   ```

# Risks
- **singer-python upgrade** (`5.14.3` → `5.19.0`): This is a minor/patch version jump across multiple releases. Behavioral changes or deprecations in the `metadata` module could affect catalog generation or sync.

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
